### PR TITLE
fix #373 breaking collecting users information on *not* starlette

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -935,7 +935,7 @@ def _build_person_data(request):
     if StarletteRequest:
         from rollbar.contrib.starlette.requests import hasuser
     else:
-        hasuser = lambda request: False
+        hasuser = lambda request: True
 
     if hasuser(request) and hasattr(request, 'user'):
         user_prop = request.user


### PR DESCRIPTION
## Description of the change

The change fixes the check to match the previous code:

  `if not StarletteRequest and hasattr(request, 'user'):`


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
 
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
